### PR TITLE
Fix package subpath error

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "rollup-plugin-commonjs": "^9.3.4",
     "rollup-plugin-livereload": "^1.0.0",
     "rollup-plugin-node-resolve": "^4.2.3",
-    "rollup-plugin-svelte": "^5.0.3",
+    "rollup-plugin-svelte": "~6.1.1",
     "rollup-plugin-terser": "^4.0.4",
     "svelte": "^3.0.0"
   },


### PR DESCRIPTION
This pull request fixes the `Package subpath './compiler.js' is not defined by "exports"` error with this fix: https://github.com/Samuel-Martineau/generator-svelte/issues/7#issuecomment-725330501.